### PR TITLE
Track translator progress in the rocks DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "c-kzg"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,6 +2298,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.16.0+8.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2353,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -3229,6 +3277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "ruint"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,6 +3942,7 @@ dependencies = [
  "reqwest 0.12.5",
  "reth-trie-common",
  "rlp",
+ "rocksdb",
  "ruint 0.3.0",
  "serde",
  "serde_json",
@@ -4777,4 +4836,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.74",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ toml = "0.8.15"
 lazy_static = "1.5.0"
 hex = "0.4.3"
 reth-trie-common = { git = "https://github.com/telosnetwork/telos-reth.git", version = "1.0.5" }
+rocksdb = "0.22.0"
 
 [dev-dependencies]
 async-trait = "0.1.80"

--- a/src/block.rs
+++ b/src/block.rs
@@ -82,7 +82,7 @@ pub enum DecodedRow {
 #[derive(Clone)]
 pub struct ProcessingEVMBlock {
     pub block_num: u32,
-    block_hash: Checksum256,
+    pub block_hash: Checksum256,
     chain_id: u64,
     result: GetBlocksResultV0,
     signed_block: Option<SignedBlock>,

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,8 +1,9 @@
-use std::sync::Arc;
+use std::{fs, path::Path, sync::Arc};
 
 use eyre::{eyre, Context, Result};
 use rocksdb::{DBWithThreadMode, Direction, IteratorMode, SingleThreaded, DB};
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use crate::types::ship_types::BlockPosition;
 
@@ -120,6 +121,15 @@ impl Database {
 
     fn block_key(number: u32) -> Vec<u8> {
         format!("blocks:{number:020}").into()
+    }
+
+    pub fn init(path: &str) -> Result<Self> {
+        if Path::new(path).exists() {
+            fs::remove_dir_all(path)
+                .map_err(|error| eyre!("Failed to delete data dir {path}. {error}"))?;
+            info!("Data dir {path} deleted.");
+        }
+        Self::open(path)
     }
 
     pub fn open(path: &str) -> Result<Self> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,156 @@
+use eyre::{eyre, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::{block, types::ship_types::BlockPosition};
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct Block {
+    pub number: u32,
+    pub hash: String,
+}
+
+impl Block {
+    pub fn new(number: u32, hash: String) -> Self {
+        Self { number, hash }
+    }
+}
+
+impl From<BlockPosition> for Block {
+    fn from(
+        BlockPosition {
+            block_num,
+            block_id,
+        }: BlockPosition,
+    ) -> Self {
+        Block {
+            number: block_num,
+            hash: block_id.to_string(),
+        }
+    }
+}
+
+impl From<block::ProcessingEVMBlock> for Block {
+    fn from(value: block::ProcessingEVMBlock) -> Self {
+        Self {
+            number: value.block_num,
+            hash: value.block_hash.to_string(),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Chain {
+    lib: Option<Block>,
+    blocks: Vec<Block>,
+}
+
+impl Chain {
+    /// Sets the new LIB.
+    /// If LIB block, or blocks after the LIB, are processed, blocks before the LIB are discarded.
+    /// Returns LIB if LIB is updated.
+    /// Panics if user tries to set previous LIB or same LIB with different hash.
+    pub fn set_lib(&mut self, lib: Block) -> Result<Option<&Block>> {
+        if self.lib() == Some(&lib) {
+            return Ok(None);
+        }
+        let Some(previous) = self.lib.take() else {
+            self.lib = Some(lib);
+            return Ok(self.lib());
+        };
+
+        if previous.number > lib.number {
+            return Err(eyre!("Cannot set previous LIB"));
+        }
+
+        self.lib = Some(lib.clone());
+        if let Some(last) = self.blocks.last() {
+            if last.number >= lib.number {
+                self.blocks = self
+                    .blocks
+                    .clone()
+                    .into_iter()
+                    .filter(|block| block.number >= lib.number)
+                    .collect();
+            }
+        }
+        Ok(self.lib())
+    }
+
+    /// Adds processed block.
+    /// Returns error if block is not next block of the last processed block.
+    pub fn add(&mut self, block: Block) -> Result<()> {
+        if self.lib.is_none() {
+            return Err(eyre!("Cannot add block if LIB is not set"));
+        };
+
+        if let Some(last) = self.blocks.last() {
+            if block.number != last.number + 1 {
+                return Err(eyre!(
+                    "Block {} is not next of the block {}",
+                    block.number,
+                    last.number
+                ));
+            }
+        }
+
+        self.blocks.push(block);
+        Ok(())
+    }
+
+    pub fn length(&self) -> usize {
+        self.blocks.len()
+    }
+
+    pub fn lib(&self) -> Option<&Block> {
+        self.lib.as_ref()
+    }
+
+    pub fn last(&self) -> Option<&Block> {
+        self.blocks.last()
+    }
+
+    pub fn get(&self, block_num: u32) -> Option<&Block> {
+        self.blocks.iter().find(|block| block.number == block_num)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add_block() {
+        let lib0 = Block::new(0, "0".to_string());
+        let lib4 = Block::new(4, "4".to_string());
+        let block1 = Block::new(1, "1".to_string());
+        let block2 = Block::new(2, "2".to_string());
+        let block3 = Block::new(3, "3".to_string());
+        let block4 = Block::new(4, "4".to_string());
+        let block5 = Block::new(5, "5".to_string());
+        let block6 = Block::new(6, "6".to_string());
+
+        let mut chain = Chain::default();
+        assert!(matches!(chain.set_lib(lib0), Ok(Some(_))));
+
+        assert!(chain.add(block1.clone()).is_ok());
+        assert!(chain.add(block3.clone()).is_err());
+        assert!(chain.add(block2.clone()).is_ok());
+        assert!(chain.add(block2.clone()).is_err());
+        assert!(chain.add(block3.clone()).is_ok());
+
+        assert_eq!(chain.length(), 3);
+
+        assert!(chain.add(block4.clone()).is_ok());
+        assert!(chain.add(block5.clone()).is_ok());
+        assert!(chain.add(block6.clone()).is_ok());
+
+        assert_eq!(chain.length(), 6);
+
+        assert!(matches!(chain.set_lib(lib4), Ok(Some(_))));
+
+        assert_eq!(chain.length(), 3);
+
+        assert!(chain.add(block5).is_err());
+        assert!(chain.add(block6).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod block;
+pub mod data;
 pub mod rlp;
 pub mod tasks;
 pub mod transaction;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ struct Args {
     /// Path to the translator configuration file
     #[arg(long, default_value = "config.toml")]
     config: String,
+    /// Start translator from clean state
+    #[arg(long, default_value = "false")]
+    clean: bool,
 }
 
 #[tokio::main]
@@ -21,7 +24,7 @@ async fn main() {
     let config: TranslatorConfig =
         toml::from_str(&config_contents).expect("Could not parse config as toml");
 
-    if let Err(e) = Translator::new(config).launch(None).await {
+    if let Err(e) = Translator::new(config).launch(None, args.clean).await {
         error!("Failed to launch translator: {e:?}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,16 +7,16 @@ use tracing::error;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
+    /// Path to the translator configuration file
     #[arg(long, default_value = "config.toml")]
     config: String,
 }
 
 #[tokio::main]
 async fn main() {
-    let args = Args::parse();
-
     tracing_subscriber::fmt::init();
 
+    let args = Args::parse();
     let config_contents = fs::read_to_string(args.config).expect("Could not read config file");
     let config: TranslatorConfig =
         toml::from_str(&config_contents).expect("Could not parse config as toml");

--- a/src/tasks/evm_block_processor.rs
+++ b/src/tasks/evm_block_processor.rs
@@ -10,11 +10,8 @@ pub async fn evm_block_processor(
     while let Some(mut block) = block_rx.recv().await {
         debug!("Processing block {}", block.block_num);
         block.deserialize();
-        if let Err(send_err) = block_tx.send(block).await {
-            error!(
-                "Failed to send block to final processor, error: {:?}",
-                send_err
-            );
+        if let Err(error) = block_tx.send(block).await {
+            error!("Failed to send block to final processor, error: {error:?}");
             break;
         }
     }

--- a/src/types/env.rs
+++ b/src/types/env.rs
@@ -32,7 +32,9 @@ lazy_static! {
 
         raw_message_channel_size: None,
         block_message_channel_size: None,
-        final_message_channel_size: None
+        final_message_channel_size: None,
+
+        data_path: "temp_db".to_string(),
     };
     pub static ref MAINNET_DEPLOY_CONFIG: TranslatorConfig = TranslatorConfig {
         chain_id: 40,
@@ -54,7 +56,9 @@ lazy_static! {
 
         raw_message_channel_size: None,
         block_message_channel_size: None,
-        final_message_channel_size: None
+        final_message_channel_size: None,
+
+        data_path: "temp_db".to_string(),
     };
     pub static ref TESTNET_GENESIS_CONFIG: TranslatorConfig = TranslatorConfig {
         chain_id: 41,
@@ -76,7 +80,9 @@ lazy_static! {
 
         raw_message_channel_size: None,
         block_message_channel_size: None,
-        final_message_channel_size: None
+        final_message_channel_size: None,
+
+        data_path: "temp_db".to_string(),
     };
     pub static ref TESTNET_DEPLOY_CONFIG: TranslatorConfig = TranslatorConfig {
         chain_id: 41,
@@ -96,6 +102,8 @@ lazy_static! {
 
         raw_message_channel_size: None,
         block_message_channel_size: None,
-        final_message_channel_size: None
+        final_message_channel_size: None,
+
+        data_path: "temp_db".to_string(),
     };
 }

--- a/tests/mock_fork.rs
+++ b/tests/mock_fork.rs
@@ -74,7 +74,7 @@ async fn mock_fork() {
     let (tx, mut rx) = mpsc::channel::<TelosEVMBlock>(1000);
 
     let mut translator = Translator::new(config);
-    match translator.launch(Some(tx)).await {
+    match translator.launch(Some(tx), true).await {
         Ok(_) => info!("Translator launched successfully"),
         Err(e) => panic!("Failed to launch translator: {:?}", e),
     }

--- a/tests/mock_fork.rs
+++ b/tests/mock_fork.rs
@@ -69,6 +69,7 @@ async fn mock_fork() {
         block_delta: 0,
         ..TESTNET_GENESIS_CONFIG.clone()
     };
+    _ = std::fs::remove_dir_all(&config.data_path);
 
     let (tx, mut rx) = mpsc::channel::<TelosEVMBlock>(1000);
 

--- a/tests/ship_read.rs
+++ b/tests/ship_read.rs
@@ -45,6 +45,7 @@ async fn evm_deploy() {
         block_delta: 1,
         ..TESTNET_GENESIS_CONFIG.clone()
     };
+    _ = std::fs::remove_dir_all(&config.data_path);
 
     tracing_subscriber::fmt::init();
 

--- a/tests/ship_read.rs
+++ b/tests/ship_read.rs
@@ -52,7 +52,7 @@ async fn evm_deploy() {
     let (tx, mut rx) = mpsc::channel::<TelosEVMBlock>(1000);
 
     let mut translator = Translator::new(config);
-    match translator.launch(Some(tx)).await {
+    match translator.launch(Some(tx), true).await {
         Ok(_) => info!("Translator launched successfully"),
         Err(e) => panic!("Failed to launch translator: {:?}", e),
     }


### PR DESCRIPTION
This PR adds tracking of the processed blocks and LIB in memory, and persist that state into RocksDB. It also adds `--clean` CLI flag, to clean DB state before launch, and `data_path` configuration parameter, to specify location of the DB.

Every commit is separate concern, so its fastest to review it commit by commit.