### PR TITLE
Use generic decode in deserialization

### DIFF
--- a/src/translator.rs
+++ b/src/translator.rs
@@ -28,9 +28,6 @@ pub struct TranslatorConfig {
     pub http_endpoint: String,
     pub ship_endpoint: String,
 
-    pub raw_ds_threads: Option<u8>,
-    pub block_process_threads: Option<u8>,
-
     pub raw_message_channel_size: Option<usize>,
     pub block_message_channel_size: Option<usize>,
     pub final_message_channel_size: Option<usize>,

--- a/src/translator.rs
+++ b/src/translator.rs
@@ -10,8 +10,6 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_tungstenite::connect_async;
 use tracing::info;
 
-pub const DEFAULT_BLOCK_PROCESS_THREADS: u8 = 4;
-
 pub const DEFAULT_RAW_MESSAGE_CHANNEL_SIZE: usize = 10000;
 pub const DEFAULT_BLOCK_PROCESS_CHANNEL_SIZE: usize = 1000;
 pub const DEFAULT_MESSAGE_FINALIZER_CHANNEL_SIZE: usize = 1000;

--- a/src/types/env.rs
+++ b/src/types/env.rs
@@ -27,9 +27,6 @@ lazy_static! {
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
 
-        raw_ds_threads: None,
-        block_process_threads: None,
-
         raw_message_channel_size: None,
         block_message_channel_size: None,
         final_message_channel_size: None
@@ -48,9 +45,6 @@ lazy_static! {
 
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
-
-        raw_ds_threads: None,
-        block_process_threads: None,
 
         raw_message_channel_size: None,
         block_message_channel_size: None,
@@ -71,9 +65,6 @@ lazy_static! {
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
 
-        raw_ds_threads: None,
-        block_process_threads: None,
-
         raw_message_channel_size: None,
         block_message_channel_size: None,
         final_message_channel_size: None
@@ -90,9 +81,6 @@ lazy_static! {
 
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
-
-        raw_ds_threads: None,
-        block_process_threads: None,
 
         raw_message_channel_size: None,
         block_message_channel_size: None,

--- a/src/types/env.rs
+++ b/src/types/env.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use alloy::primitives::FixedBytes;
 use lazy_static::lazy_static;
 
-use crate::translator::TranslatorConfig;
+use crate::translator::{default_channel_size, TranslatorConfig};
 
 pub const ANTELOPE_EPOCH_MS: u64 = 946684800000;
 pub const ANTELOPE_INTERVAL_MS: u64 = 500;
@@ -27,9 +27,9 @@ lazy_static! {
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
 
-        raw_message_channel_size: None,
-        block_message_channel_size: None,
-        final_message_channel_size: None
+        raw_message_channel_size: default_channel_size(),
+        block_message_channel_size: default_channel_size(),
+        final_message_channel_size: default_channel_size()
     };
     pub static ref MAINNET_DEPLOY_CONFIG: TranslatorConfig = TranslatorConfig {
         chain_id: 40,
@@ -46,9 +46,9 @@ lazy_static! {
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
 
-        raw_message_channel_size: None,
-        block_message_channel_size: None,
-        final_message_channel_size: None
+        raw_message_channel_size: default_channel_size(),
+        block_message_channel_size: default_channel_size(),
+        final_message_channel_size: default_channel_size()
     };
     pub static ref TESTNET_GENESIS_CONFIG: TranslatorConfig = TranslatorConfig {
         chain_id: 41,
@@ -65,9 +65,9 @@ lazy_static! {
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
 
-        raw_message_channel_size: None,
-        block_message_channel_size: None,
-        final_message_channel_size: None
+        raw_message_channel_size: default_channel_size(),
+        block_message_channel_size: default_channel_size(),
+        final_message_channel_size: default_channel_size()
     };
     pub static ref TESTNET_DEPLOY_CONFIG: TranslatorConfig = TranslatorConfig {
         chain_id: 41,
@@ -82,8 +82,8 @@ lazy_static! {
         http_endpoint: String::from("http://127.0.0.1:8888"),
         ship_endpoint: String::from("ws://127.0.0.1:29999"),
 
-        raw_message_channel_size: None,
-        block_message_channel_size: None,
-        final_message_channel_size: None
+        raw_message_channel_size: default_channel_size(),
+        block_message_channel_size: default_channel_size(),
+        final_message_channel_size: default_channel_size()
     };
 }


### PR DESCRIPTION
This is a spin of of issue #34 , it removes obsolete parameters, uses default serde values instead of option for configuration and uses generic decode in deserialization.

Idea is to merge chores before the main task to avoid merge conflicts.
